### PR TITLE
Add comprehensive setup.py packaging metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,47 @@
-from setuptools import setup, find_packages
+from pathlib import Path
+from setuptools import find_packages, setup
+
+BASE_DIR = Path(__file__).parent
+README_PATH = BASE_DIR / "README.md"
+REQUIREMENTS_PATH = BASE_DIR / "requirements.txt"
+
+long_description = README_PATH.read_text(encoding="utf-8") if README_PATH.exists() else ""
+
+def parse_requirements(path: Path):
+    if not path.exists():
+        return []
+
+    requirements = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        requirements.append(line)
+    return requirements
 
 setup(
     name="maintainability-score-analyzer",
-    version="0.1",
+    version="0.1.0",
+    description="Analyze source files to compute maintainability metrics such as the Maintainability Index.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
-    install_requires=[
-        "libclang",
-        "javalang",
-    ],
+    install_requires=parse_requirements(REQUIREMENTS_PATH),
+    python_requires=">=3.9",
     include_package_data=True,
     package_data={
         "maintainability_score_analyzer": ["copilot_instructions.txt"],
     },
-    # CLI functionality removed
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    keywords=[
+        "maintainability",
+        "metrics",
+        "static analysis",
+    ],
+    url="https://example.com/maintainability-score-analyzer",
 )


### PR DESCRIPTION
## Summary
- add a robust setup.py that reads project metadata from README and requirements.txt
- include classifiers, keywords, and python version requirement for packaging

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68fe9062dda8832bae889b598b98a7db